### PR TITLE
Moving progress bar

### DIFF
--- a/client/components/spotify-module.js
+++ b/client/components/spotify-module.js
@@ -112,7 +112,7 @@ export class SpotifyModule extends Component {
 
     return (
       <div>
-        <Card style={{ width: '600px' }}>
+        <Card style={{ width: '420px' }}>
            <PlaylistDropdown
             trackData = {trackData}
             handleChange = {this.handleChange}

--- a/client/components/spotify-module.js
+++ b/client/components/spotify-module.js
@@ -112,7 +112,7 @@ export class SpotifyModule extends Component {
 
     return (
       <div>
-        <Card style={{ width: '420px' }}>
+        <Card style={{ width: '425px' }}>
            <PlaylistDropdown
             trackData = {trackData}
             handleChange = {this.handleChange}

--- a/client/components/spotify-overlay.js
+++ b/client/components/spotify-overlay.js
@@ -35,7 +35,7 @@ class SpotifyOverlay extends Component {
     return (
       <div
         style={{
-          width:'420px'
+          width:'425px'
         }}
       >
         {this.props.votecycle && this.props.votecycle.id ?

--- a/client/components/spotify-overlay.js
+++ b/client/components/spotify-overlay.js
@@ -17,7 +17,7 @@ class SpotifyOverlay extends Component {
   componentWillUnmount() {
     clearInterval(this.timer)
   }
-  
+
   tick = async () => {
     await this.props.activeVotecycle(this.props.userId)
     return this.props.getVotes(this.props.votecycle)
@@ -30,13 +30,13 @@ class SpotifyOverlay extends Component {
         return total + voteChoice.votes
       }, 0)
     }
-  
-  
+
+
     return (
       <div
         style={{
-          width:'600px'
-        }}  
+          width:'420px'
+        }}
       >
         {this.props.votecycle && this.props.votecycle.id ?
           this.props.votecycle.votechoices

--- a/client/components/spotify-voteline.js
+++ b/client/components/spotify-voteline.js
@@ -5,8 +5,6 @@ import { Segment, Image, Progress, Loader, Dimmer } from 'semantic-ui-react'
 import Vibrant from 'node-vibrant'
 import getColors from './util/getColors'
 
-
-
 class SpotifyVoteline extends Component {
   constructor(props) {
     super(props)
@@ -74,7 +72,7 @@ class SpotifyVoteline extends Component {
                 alignItems: 'center'
               }}>
               <h1
-                style={{ 
+                style={{
                   margin: '.5rem'
 
                 }}
@@ -103,34 +101,28 @@ class SpotifyVoteline extends Component {
                     style={{
                       display: 'flex',
                       justifyContent: 'space-between',
+                      alignItems: 'center'
                     }}
                   >
                     <div
-                      style={{ 
+                      style={{
                         textAlign: 'left',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         width: '280px',
-                        margin: '0.5rem'
+                        margin: '0.5rem',
                     }}
                     >
                       <strong>{votechoice.track.name}</strong><br />
                       {votechoice.track.artist}
-                    </div>
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center'
-                      }}
-                    >
                       <Progress
                         progress='value'
                         value={votechoice.votes}
                         total={totalVotes}
                         inverted
                         color='grey'
-                        style={{ width: '10rem', margin: '0.5rem' }}
+                        style={{ width: '16rem', margin: '0.5rem 0 .5rem' }}
                       />
                     </div>
                   </div>

--- a/client/components/spotify-voteline.js
+++ b/client/components/spotify-voteline.js
@@ -122,7 +122,7 @@ class SpotifyVoteline extends Component {
                         total={totalVotes}
                         inverted
                         color='grey'
-                        style={{ width: '16rem', margin: '0.5rem 0 .5rem' }}
+                        style={{ width: '19rem', margin: '0.5rem 0 .5rem' }}
                       />
                     </div>
                   </div>

--- a/public/style.css
+++ b/public/style.css
@@ -43,3 +43,7 @@ html, body, #app {
 .ui.inverted.progress .bar>.progress {
   color: #000000 !important;
 }
+
+.ui.grey.inverted.progress .bar {
+  background-color: #ffffff;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -41,7 +41,7 @@ html, body, #app {
 }
 
 .ui.inverted.progress .bar>.progress {
-  color: #000000 !important;
+  color: rgba(0,0,0,.6) !important;
 }
 
 .ui.grey.inverted.progress .bar {


### PR DESCRIPTION
- moved the progress bar below the track information
- changed the width of spotify-module and spotify-overlay to 425px
- changed the color of the progress bars to white
- changed the color of the text in the progress bars to dark grey of subtitle and buttons
- increased width of progress bars to roughly match max text width
